### PR TITLE
Remove MAINTAINER in RHEL image

### DIFF
--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -3,8 +3,6 @@ FROM openshift/base-rhel7
 # This image provides an Apache+PHP environment for running PHP
 # applications.
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 ENV PHP_VERSION=5.5 \

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -3,8 +3,6 @@ FROM openshift/base-rhel7
 # This image provides an Apache+PHP environment for running PHP
 # applications.
 
-MAINTAINER docker@softwarecollections.org
-
 EXPOSE 8080
 
 ENV PHP_VERSION=5.6 \


### PR DESCRIPTION
It is recommended not to use MAINTAINER in RHEL images.