### PR TITLE
fix opcache config path, fix #62

### DIFF
--- a/5.5/contrib/etc/php.d/opcache.ini.template
+++ b/5.5/contrib/etc/php.d/opcache.ini.template
@@ -1,5 +1,5 @@
 ; Enable Zend OPcache extension module
-zend_extension=/opt/rh/php55/root/usr/lib64/php/modules/opcache.so
+zend_extension=opcache.so
 
 ; Determines if Zend OPCache is enabled
 opcache.enable=1

--- a/5.6/contrib/etc/php.d/10-opcache.ini.template
+++ b/5.6/contrib/etc/php.d/10-opcache.ini.template
@@ -1,5 +1,5 @@
 ; Enable Zend OPcache extension module
-zend_extension=/opt/rh/php54/root/usr/lib64/php/modules/opcache.so
+zend_extension=opcache.so
 
 ; Determines if Zend OPCache is enabled
 opcache.enable=1
@@ -63,7 +63,7 @@ opcache.fast_shutdown=1
 ; The location of the OPcache blacklist file (wildcards allowed).
 ; Each OPcache blacklist file is a text file that holds the names of files
 ; that should not be accelerated.
-opcache.blacklist_filename=/opt/rh/php54/root/etc/php.d/opcache*.blacklist
+opcache.blacklist_filename=/etc/opt/rh/rh-php56/php.d/opcache*.blacklist
 
 ; Allows exclusion of large files from being cached. By default all files
 ; are cached.


### PR DESCRIPTION
Since 5.5, "zend_extension" don't requires full path, so safer to fix both 5.5 and 5.6
