### PR TITLE
Configure Apache to write access logs to stdout instead of file

### DIFF
--- a/5.5/contrib/etc/httpdconf.sed
+++ b/5.5/contrib/etc/httpdconf.sed
@@ -5,5 +5,5 @@ s%^DocumentRoot "/opt/rh/httpd24/root/var/www/html"%DocumentRoot "/opt/app-root/
 s%^<Directory "/opt/rh/httpd24/root/var/www/html"%<Directory "/opt/app-root/src"%
 s%^<Directory "/opt/rh/httpd24/root/var/html"%<Directory "/opt/app-root/src"%
 s%^ErrorLog "logs/error_log"%ErrorLog "/tmp/error_log"%
-s%CustomLog "logs/access_log"%CustomLog "/tmp/access_log"%
+s%CustomLog "logs/access_log"%CustomLog "|/usr/bin/cat"%
 151s%AllowOverride None%AllowOverride All%

--- a/5.6/contrib/etc/httpdconf.sed
+++ b/5.6/contrib/etc/httpdconf.sed
@@ -5,5 +5,5 @@ s%^DocumentRoot "/opt/rh/httpd24/root/var/www/html"%DocumentRoot "/opt/app-root/
 s%^<Directory "/opt/rh/httpd24/root/var/www/html"%<Directory "/opt/app-root/src"%
 s%^<Directory "/opt/rh/httpd24/root/var/html"%<Directory "/opt/app-root/src"%
 s%^ErrorLog "logs/error_log"%ErrorLog "/tmp/error_log"%
-s%CustomLog "logs/access_log"%CustomLog "/tmp/access_log"%
+s%CustomLog "logs/access_log"%CustomLog "|/usr/bin/cat"%
 151s%AllowOverride None%AllowOverride All%


### PR DESCRIPTION
I've configured Apache to use [piped logs](http://httpd.apache.org/docs/2.4/logs.html#piped) and now it's writing access logs to stdout instead of `/tmp/access_log`. This change addresses to https://bugzilla.redhat.com/show_bug.cgi?id=1231862

PTAL @rhcarvalho @mfojtik
I've tested in on with php55/php56 and CentOS7.

A couple of related questions:
1) now there is no `/tmp/access_log`. Is it ok or we should provide backward compatibility? If we should I think we may change `cat` to `tee` and it would work fine
2) (if the answer to the first question is "No") Should we update our documentation like we did in https://github.com/openshift/openshift-docs/pull/887?
