### PR TITLE
One option to rule them all

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -42,6 +42,7 @@ RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/con
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php56-php.conf && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
     mkdir /tmp/sessions && \
+    chmod    a+rwx /opt/rh/httpd24/root/etc/httpd/conf.d && \
     chmod -R a+rwx /etc/opt/rh/rh-php56 && \
     chmod -R a+rwx /opt/rh/httpd24/root/var/run/httpd && \
     chmod -R a+rwx /tmp/sessions && \

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -14,12 +14,11 @@ LABEL io.k8s.description="Platform for building and running PHP 5.6 applications
       io.openshift.tags="builder,php,php56,rh-php56"
 
 # Labels consumed by Red Hat build service
-LABEL Component="rh-php56-docker" \
+LABEL Name="rhscl/php-56-rhel7" \
       BZComponent="rh-php56-docker" \
-      Architecture="x86_64" \
-      Name="rhscl/rh-php56-rhel7" \
       Version="5.6" \
-      Release="3"
+      Release="3" \
+      Architecture="x86_64"
 
 # Install Apache httpd and PHP
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -44,6 +44,7 @@ RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/con
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php56-php.conf && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
     mkdir /tmp/sessions && \
+    chmod    a+rwx /opt/rh/httpd24/root/etc/httpd/conf.d && \
     chmod -R a+rwx /etc/opt/rh/rh-php56 && \
     chmod -R a+rwx /opt/rh/httpd24/root/var/run/httpd && \
     chmod -R a+rwx /tmp/sessions && \

--- a/5.6/README.md
+++ b/5.6/README.md
@@ -123,10 +123,10 @@ You can also override the entire directory used to load the PHP configuration by
 
 For other configuration options:
 * **PHP_OPTIONS**
-  * Allow to set any PHP options, space separated list.
+  * Allow to set any PHP option, space separated list.
   * Example: PHP_OPTIONS="memory_limit=32M"
 * **HTTPD_OPTIONS**
-  * Allow to set any HTTPD options, space separated list. Spaces have to be encoded as %20, see RFC-3986.
+  * Allow to set any HTTPD option, space separated list. Spaces have to be encoded as %20, see RFC-3986.
   * Example: HTTPD_OPTIONS="StartServers%202 MinSpareServers%202 MaxRequestWorkers%208"
 * **PHP_DISABLED_EXT**
   * Allow to disable unneeded extensions

--- a/5.6/README.md
+++ b/5.6/README.md
@@ -121,6 +121,17 @@ You can also override the entire directory used to load the PHP configuration by
 * **PHP_INI_SCAN_DIR**
   * Path to scan for additional ini configuration files
 
+For other configuration options:
+* **PHP_OPTIONS**
+  * Allow to set any PHP options, space separated list.
+  * Example: PHP_OPTIONS="memory_limit=32M"
+* **HTTPD_OPTIONS**
+  * Allow to set any HTTPD options, space separated list. Spaces have to be encoded as %20, see RFC-3986.
+  * Example: HTTPD_OPTIONS="StartServers%202 MinSpareServers%202 MaxRequestWorkers%208"
+* **PHP_DISABLED_EXT**
+  * Allow to disable unneeded extensions
+  * Example: PHP_DISABLED_EXT="xdebug intl pgsql"
+
 Apache .htaccess file
 ---------------------
 

--- a/5.6/s2i/bin/run
+++ b/5.6/s2i/bin/run
@@ -20,4 +20,27 @@ export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-/etc/opt/rh/rh-php56/php.d}
 envsubst < /opt/app-root/etc/php.ini.template > $PHPRC
 envsubst < /opt/app-root/etc/php.d/10-opcache.ini.template > $PHP_INI_SCAN_DIR/10-opcache.ini
 
+HTTPD_CONFDIR=/opt/rh/httpd24/root/etc/httpd/conf.d
+
+if [ -n "$PHP_OPTIONS" ]; then
+  for opt in $PHP_OPTIONS
+  do    echo $opt
+  done >$PHP_INI_SCAN_DIR/99-options.ini
+fi
+
+if [ -n "$HTTPD_OPTIONS" ]; then
+  for opt in $HTTPD_OPTIONS
+  do    echo $opt
+  done >$HTTPD_CONFDIR/options.conf
+fi
+
+if [ -n "$PHP_DISABLED_EXT" ]; then
+  for $ext in $PHP_DISABLED_EXT
+  do
+    if [ -f $PHP_INI_SCAN_DIR/??-$ext.ini ]
+    then mv $PHP_INI_SCAN_DIR/??-$ext.ini $PHP_INI_SCAN_DIR/$ext.off
+    fi
+  done
+fi
+
 exec httpd -D FOREGROUND

--- a/5.6/s2i/bin/run
+++ b/5.6/s2i/bin/run
@@ -24,21 +24,22 @@ HTTPD_CONFDIR=/opt/rh/httpd24/root/etc/httpd/conf.d
 
 if [ -n "$PHP_OPTIONS" ]; then
   for opt in $PHP_OPTIONS
-  do    echo $opt
-  done >$PHP_INI_SCAN_DIR/99-options.ini
+  do php -r "echo urldecode('$opt') . PHP_EOL;"
+  done > $PHP_INI_SCAN_DIR/99-options.ini
 fi
 
 if [ -n "$HTTPD_OPTIONS" ]; then
   for opt in $HTTPD_OPTIONS
-  do    echo $opt
-  done >$HTTPD_CONFDIR/options.conf
+  do php -r "echo urldecode('$opt') . PHP_EOL;"
+  done > $HTTPD_CONFDIR/options.conf
 fi
 
 if [ -n "$PHP_DISABLED_EXT" ]; then
-  for $ext in $PHP_DISABLED_EXT
+  for ext in $PHP_DISABLED_EXT
   do
     if [ -f $PHP_INI_SCAN_DIR/??-$ext.ini ]
     then mv $PHP_INI_SCAN_DIR/??-$ext.ini $PHP_INI_SCAN_DIR/$ext.off
+    else echo "ERROR: $ext.ini not found in $PHP_INI_SCAN_DIR"
     fi
   done
 fi

--- a/5.6/s2i/bin/usage
+++ b/5.6/s2i/bin/usage
@@ -12,4 +12,26 @@ s2i build https://github.com/openshift/sti-php.git --context-dir=/5.6/test/test-
 
 You can then run the resulting image via:
 docker run -p 8080:8080 php-test-app
+
+Environment variables
+---------------------
+
+The image recognizes the following environment variables that you can set during
+initialization by passing `-e VAR=VALUE` to the Docker run command.
+
+|    Variable name           |    Description                                      |
+| -------------------------- | --------------------------------------------------- |
+| ERROR_REPORTING            | PHP error_reporting, default E_ALL & ~E_NOTICE      |
+| DISPLAY_ERRORS             | PHP display_error, default ON                       |
+| DISPLAY_STARTUP_ERRORS     | PHP display_startup_errors, default OFF             |
+| TRACK_ERRORS               | PHP track_errors, default OFF                       |
+| HTML_ERRORS                | PHP html_errors, default ON                         |
+| INCLUDE_PATH               | PHP include_path                                    |
+| SESSION_PATH               | PHP session_path, default /tmp/sessions             |
+| OPCACHE_MEMORY_CONSUMPTION | PHP opcache.memory_consumption, default 16M         |
+| OPCACHE_REVALIDATE_FREQ    | PHP opcache.revalidate_freq, default 2              |
+| PHP_OPTIONS                | PHP additional options, e.g. memory_limit=32M       |
+| PHP_DISABLED_EXT           | PHP disabled extensions, e.g. "xdebug intl"         |
+| HTTPD_OPTIONS              | HTTPD additional options, e.g. MaxRequestWorkers=16 |
+
 EOF

--- a/5.6/s2i/bin/usage
+++ b/5.6/s2i/bin/usage
@@ -19,19 +19,21 @@ Environment variables
 The image recognizes the following environment variables that you can set during
 initialization by passing `-e VAR=VALUE` to the Docker run command.
 
-|    Variable name           |    Description                                      |
-| -------------------------- | --------------------------------------------------- |
-| ERROR_REPORTING            | PHP error_reporting, default E_ALL & ~E_NOTICE      |
-| DISPLAY_ERRORS             | PHP display_error, default ON                       |
-| DISPLAY_STARTUP_ERRORS     | PHP display_startup_errors, default OFF             |
-| TRACK_ERRORS               | PHP track_errors, default OFF                       |
-| HTML_ERRORS                | PHP html_errors, default ON                         |
-| INCLUDE_PATH               | PHP include_path                                    |
-| SESSION_PATH               | PHP session_path, default /tmp/sessions             |
-| OPCACHE_MEMORY_CONSUMPTION | PHP opcache.memory_consumption, default 16M         |
-| OPCACHE_REVALIDATE_FREQ    | PHP opcache.revalidate_freq, default 2              |
-| PHP_OPTIONS                | PHP additional options, e.g. memory_limit=32M       |
-| PHP_DISABLED_EXT           | PHP disabled extensions, e.g. "xdebug intl"         |
-| HTTPD_OPTIONS              | HTTPD additional options, e.g. MaxRequestWorkers=16 |
+|    Variable name           |    Description                                        |
+| -------------------------- | ----------------------------------------------------- |
+| ERROR_REPORTING            | PHP error_reporting, default E_ALL & ~E_NOTICE        |
+| DISPLAY_ERRORS             | PHP display_error, default ON                         |
+| DISPLAY_STARTUP_ERRORS     | PHP display_startup_errors, default OFF               |
+| TRACK_ERRORS               | PHP track_errors, default OFF                         |
+| HTML_ERRORS                | PHP html_errors, default ON                           |
+| INCLUDE_PATH               | PHP include_path                                      |
+| SESSION_PATH               | PHP session_path, default /tmp/sessions               |
+| OPCACHE_MEMORY_CONSUMPTION | PHP opcache.memory_consumption, default 16M           |
+| OPCACHE_REVALIDATE_FREQ    | PHP opcache.revalidate_freq, default 2                |
+| PHP_OPTIONS                | PHP additional options, e.g. memory_limit=32M         |
+| PHP_DISABLED_EXT           | PHP disabled extensions, e.g. "xdebug intl"           |
+| HTTPD_OPTIONS              | HTTPD additional options, e.g. MaxRequestWorkers%2016 |
 
+Notice: PHP_OPTIONS, HTTPD_OPTIONS and PHP_DISABLED_EXT are space separated list.
+        Spaces and should be encoded as %20, see RFC-3986.
 EOF

--- a/5.6/s2i/bin/usage
+++ b/5.6/s2i/bin/usage
@@ -35,5 +35,5 @@ initialization by passing `-e VAR=VALUE` to the Docker run command.
 | HTTPD_OPTIONS              | HTTPD additional options, e.g. MaxRequestWorkers%2016 |
 
 Notice: PHP_OPTIONS, HTTPD_OPTIONS and PHP_DISABLED_EXT are space separated list.
-        Spaces and should be encoded as %20, see RFC-3986.
+        Spaces have to be encoded as %20, see RFC-3986.
 EOF

--- a/5.6/test/run
+++ b/5.6/test/run
@@ -51,7 +51,8 @@ prepare() {
 }
 
 run_test_application() {
-  run_args=${CONTAINER_ARGS:-}
+  run_args="${CONTAINER_ARGS:-} -e PHP_OPTIONS=memory_limit=32M"
+  info "docker run --user=100001 ${run_args} --cidfile=${cid_file} -p ${test_port} ${IMAGE_NAME}-testapp"
   docker run --user=100001 ${run_args} --cidfile=${cid_file} -p ${test_port} ${IMAGE_NAME}-testapp
 }
 
@@ -63,6 +64,9 @@ cleanup_test_app() {
       docker rm $(cat $cid_file)
     fi
     rm $cid_file
+  fi
+  if [ -f $out_file ]; then
+    rm $out_file
   fi
 }
 
@@ -77,6 +81,15 @@ cleanup() {
 check_result() {
   local result="$1"
   if [[ "$result" != "0" ]]; then
+    info "TEST FAILED (${result})"
+    cleanup
+    exit $result
+  fi
+}
+
+check_not_result() {
+  local result="$1"
+  if [[ "$result" = "0" ]]; then
     info "TEST FAILED (${result})"
     cleanup
     exit $result
@@ -136,7 +149,7 @@ test_connection() {
   local attempt=1
   local result=1
   while [ $attempt -le $max_attempts ]; do
-    response_code=$(curl -s -w %{http_code} -o /dev/null http://$(container_ip):${test_port}/)
+    response_code=$(curl -s -w %{http_code} -o ${out_file} http://$(container_ip):${test_port}/)
     status=$?
     if [ $status -eq 0 ]; then
       if [ $response_code -eq 200 ]; then
@@ -162,10 +175,23 @@ test_application() {
 
   test_connection
   check_result $?
+
+  info "Checking the PHP_OPTIONS"
+  grep memory_limit ${out_file}
+
+  info "Verify memory_limit is 32M"
+  grep memory_limit ${out_file} | grep 32M
+  check_result $?
+
+  info "Verify memory_limit not 128M"
+  grep memory_limit ${out_file} | grep 128M
+  check_not_result $?
+
   cleanup_test_app
 }
 
 cid_file=$(mktemp -u --suffix=.cid)
+out_file=$(mktemp -u --suffix=.out)
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Include common Makefile code.
 BASE_IMAGE_NAME = php
-VERSIONS = 5.5 5.6
+VERSIONS = 5.6 5.5
 OPENSHIFT_NAMESPACES = 5.5
 
 # Include common Makefile code.


### PR DESCRIPTION
Here is a proposal to allow more configuration of the image.

See https://github.com/openshift/sti-base/issues/69

The PHP_OPTIONS allows to set any PHP option
The HTTPD_OPTIONS allows to set any HTTPD option
The PHP_DISABLED_EXT allows ti disabled unneeded extension

Good test (low memory image) will be to use PHP_OPTIONS=memory_limit=32M, HTTPD_OPTIONS=MaxRequestWorkers=4 and PHP_DISABLED_EXT="gd intl ldap xdebug"