### PR TITLE
Removed --no-scripts parameter for composer and fixed missing function in assemble

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -35,6 +35,7 @@ COPY ./contrib/ /opt/app-root
 # random UID.
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/php55-php.conf && \
+    cp -a /opt/app-root/etc/php.ini.template /etc/opt/rh/rh-php55/php.ini && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
     mkdir /tmp/sessions && \
     chmod -R a+rwx /opt/rh/php55/root/etc && \

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -41,6 +41,7 @@ COPY ./contrib/ /opt/app-root
 # random UID.
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/php55-php.conf && \
+    cp -a /opt/app-root/etc/php.ini.template /etc/opt/rh/rh-php55/php.ini && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
     mkdir /tmp/sessions && \
     chmod -R a+rwx /opt/rh/php55/root/etc && \

--- a/5.5/README.md
+++ b/5.5/README.md
@@ -53,7 +53,12 @@ Repository organization
 
             Used to install the sources into the location where the application
             will be run and prepare the application for deployment (eg. installing
-            modules using npm, etc..)
+            modules using npm, etc..) The assemle script installs [composer](https://getcomposer.org/) and executes 
+            
+            ```
+            ./composer.phar install --no-interaction --no-ansi --optimize-autoloader
+            ```
+            if a composer.json file is found in the source respository
 
         *   **run**
 

--- a/5.5/s2i/bin/assemble
+++ b/5.5/s2i/bin/assemble
@@ -2,6 +2,12 @@
 
 set -e
 
+fix-permissions () {
+  chgrp -R 0 $1
+  chmod -R g+rw $1
+}
+
+
 echo "---> Installing application source..."
 cp -Rf /tmp/src/. ./
 

--- a/5.5/s2i/bin/assemble
+++ b/5.5/s2i/bin/assemble
@@ -12,7 +12,7 @@ if [ -f composer.json ]; then
   php -r "readfile('https://getcomposer.org/installer');" | php
 
   # Install App dependencies using Composer
-  ./composer.phar install --no-interaction --no-ansi --no-scripts --optimize-autoloader
+  ./composer.phar install --no-interaction --no-ansi --optimize-autoloader
 
   if [ ! -f composer.lock ]; then
     echo -e "\nConsider adding a 'composer.lock' file into your source repository.\n"

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -37,6 +37,7 @@ COPY ./contrib/ /opt/app-root
 # random UID.
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php56-php.conf && \
+    cp -a /opt/app-root/etc/php.ini.template /etc/opt/rh/rh-php56/php.ini && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
     mkdir /tmp/sessions && \
     chmod -R a+rwx /etc/opt/rh/rh-php56 && \

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -42,6 +42,7 @@ COPY ./contrib/ /opt/app-root
 # random UID.
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php56-php.conf && \
+    cp -a /opt/app-root/etc/php.ini.template /etc/opt/rh/rh-php56/php.ini && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
     mkdir /tmp/sessions && \
     chmod -R a+rwx /etc/opt/rh/rh-php56 && \

--- a/5.6/README.md
+++ b/5.6/README.md
@@ -53,7 +53,12 @@ Repository organization
 
             Used to install the sources into the location where the application
             will be run and prepare the application for deployment (eg. installing
-            modules using npm, etc..)
+            modules using npm, etc..). The assemle script installs [composer](https://getcomposer.org/) and executes 
+            
+            ```
+            ./composer.phar install --no-interaction --no-ansi --optimize-autoloader
+            ```
+            if a composer.json file is found in the source respository
 
         *   **run**
 

--- a/5.6/s2i/bin/assemble
+++ b/5.6/s2i/bin/assemble
@@ -2,6 +2,12 @@
 
 set -e
 
+fix-permissions () {
+  chgrp -R 0 $1
+  chmod -R g+rw $1
+}
+
+
 echo "---> Installing application source..."
 cp -Rf /tmp/src/. ./
 

--- a/5.6/s2i/bin/assemble
+++ b/5.6/s2i/bin/assemble
@@ -12,7 +12,7 @@ if [ -f composer.json ]; then
   php -r "readfile('https://getcomposer.org/installer');" | php
 
   # Install App dependencies using Composer
-  ./composer.phar install --no-interaction --no-ansi --no-scripts --optimize-autoloader
+  ./composer.phar install --no-interaction --no-ansi --optimize-autoloader
 
   if [ ! -f composer.lock ]; then
     echo -e "\nConsider adding a 'composer.lock' file into your source repository.\n"


### PR DESCRIPTION
Hi,

as I mentioned in [#73](https://github.com/openshift/sti-php/issues/73) the parameter --no-scripts must be removed to successfully build [symfony 2 projects](http://symfony.com/).

In this Pull Request i removed the parameter and fixed the assemble script, as it was it did not run on my ose3 testplatform.
Since php 5.3 the property date.timezone = in the php.ini must be set. I Therefore updated the dockerfiles to copy the available php.ini.template.

Improvements are welcome.
Thanks
