### PR TITLE
Pass all env to apache

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -36,7 +36,10 @@ COPY ./contrib/ /opt/app-root
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/php55-php.conf && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
-    mkdir /tmp/sessions && \
+    mkdir -p /tmp/sessions /opt/app-root/etc/conf.d && \
+    touch /opt/app-root/etc/conf.d/env.conf && \
+    ln -sf /opt/app-root/etc/conf.d/env.conf /opt/rh/httpd24/root/etc/httpd/conf.d/env.conf && \
+    chmod -R a+rwx /opt/app-root/etc/conf.d && \
     chmod -R a+rwx /opt/rh/php55/root/etc && \
     chmod -R a+rwx /opt/rh/httpd24/root/var/run/httpd && \
     chmod -R a+rwx /tmp/sessions && \

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -42,7 +42,10 @@ COPY ./contrib/ /opt/app-root
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/php55-php.conf && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
-    mkdir /tmp/sessions && \
+    mkdir -p /tmp/sessions /opt/app-root/etc/conf.d && \
+    touch /opt/app-root/etc/conf.d/env.conf && \
+    ln -sf /opt/app-root/etc/conf.d/env.conf /opt/rh/httpd24/root/etc/httpd/conf.d/env.conf && \
+    chmod -R a+rwx /opt/app-root/etc/conf.d && \
     chmod -R a+rwx /opt/rh/php55/root/etc && \
     chmod -R a+rwx /opt/rh/httpd24/root/var/run/httpd && \
     chmod -R a+rwx /tmp/sessions && \

--- a/5.5/s2i/bin/run
+++ b/5.5/s2i/bin/run
@@ -20,4 +20,7 @@ export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-/opt/rh/php55/root/etc/php.d}
 envsubst < /opt/app-root/etc/php.ini.template > /opt/rh/php55/root/etc/php.ini
 envsubst < /opt/app-root/etc/php.d/opcache.ini.template > /opt/rh/php55/root/etc/php.d/opcache.ini
 
+# Pass the environment variable to Apache
+env | awk -F'=' '{print "PassEnv "$1}' > /opt/app-root/etc/conf.d/env.conf
+
 exec httpd -D FOREGROUND

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -38,7 +38,10 @@ COPY ./contrib/ /opt/app-root
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php56-php.conf && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
-    mkdir /tmp/sessions && \
+    mkdir -p /tmp/sessions /opt/app-root/etc/conf.d && \
+    touch /opt/app-root/etc/conf.d/env.conf && \
+    ln -sf /opt/app-root/etc/conf.d/env.conf /opt/rh/httpd24/root/etc/httpd/conf.d/env.conf && \
+    chmod -R a+rwx /opt/app-root/etc/conf.d && \
     chmod -R a+rwx /etc/opt/rh/rh-php56 && \
     chmod -R a+rwx /opt/rh/httpd24/root/var/run/httpd && \
     chmod -R a+rwx /tmp/sessions && \

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -43,7 +43,10 @@ COPY ./contrib/ /opt/app-root
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php56-php.conf && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
-    mkdir /tmp/sessions && \
+    mkdir -p /tmp/sessions /opt/app-root/etc/conf.d && \
+    touch /opt/app-root/etc/conf.d/env.conf && \
+    ln -sf /opt/app-root/etc/conf.d/env.conf /opt/rh/httpd24/root/etc/httpd/conf.d/env.conf && \
+    chmod -R a+rwx /opt/app-root/etc/conf.d && \
     chmod -R a+rwx /etc/opt/rh/rh-php56 && \
     chmod -R a+rwx /opt/rh/httpd24/root/var/run/httpd && \
     chmod -R a+rwx /tmp/sessions && \

--- a/5.6/s2i/bin/run
+++ b/5.6/s2i/bin/run
@@ -11,7 +11,6 @@ export INCLUDE_PATH=${INCLUDE_PATH:-.:/opt/app-root/src:/opt/rh/rh-php56/root/us
 export SESSION_PATH=${SESSION_PATH:-/tmp/sessions}
 # TODO should be dynamically calculated based on container memory limit/16
 export OPCACHE_MEMORY_CONSUMPTION=${OPCACHE_MEMORY_CONSUMPTION:-16M} 
-
 export OPCACHE_REVALIDATE_FREQ=${OPCACHE_REVALIDATE_FREQ:-2}
 
 export PHPRC=${PHPRC:-/etc/opt/rh/rh-php56/php.ini}
@@ -19,5 +18,8 @@ export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-/etc/opt/rh/rh-php56/php.d}
 
 envsubst < /opt/app-root/etc/php.ini.template > $PHPRC
 envsubst < /opt/app-root/etc/php.d/10-opcache.ini.template > $PHP_INI_SCAN_DIR/10-opcache.ini
+
+# Pass the environment variable to Apache
+env | awk -F'=' '{print "PassEnv "$1}' > /opt/app-root/etc/conf.d/env.conf
 
 exec httpd -D FOREGROUND


### PR DESCRIPTION
Fixes: https://github.com/openshift/sti-php/issues/83

@bparees @remicollet is this sane? (we pass all env in other images, so php should not be special here). This will allow users to do $_ENV